### PR TITLE
Remove deploy guide

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -14,13 +14,13 @@
 /** @type {import('@docusaurus/plugin-content-docs').SidebarsConfig} */
 const sidebars = {
 
-  docsbars: ['cbdb-overview',
+  docsbars: ['cbdb-overview'
 
-  {
-    type: 'category',
-    label: 'Deployment Guides',
-    items: ['cbdb-op-deploy-guide']
-  },
+  // {
+  //   type: 'category',
+  //   label: 'Deployment Guides',
+  //   items: ['cbdb-op-deploy-guide']
+  // },
 
   ]
 }


### PR DESCRIPTION
Remove the deploy guide from sidebar because it is not applicable.