### PR TITLE
Update gitignore to prevent local build folders being pushed to upstream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
-node_modules
+node_modules/
 .docusaurus
 .DS_Store
+build/
+local-preview-for-cbdb-site/


### PR DESCRIPTION
Update .gitignore to prevent local build folders from being pushed to upstream