### PR TITLE
Debug doc "Edit" links in CBDB website

### DIFF
--- a/docs/cbdb-vs-gp-features.md
+++ b/docs/cbdb-vs-gp-features.md
@@ -1,8 +1,8 @@
 ---
-title: Comparision with Greenplum Features
+title: Comparison with Greenplum Features
 ---
 
-# Comparision with Greenplum Features
+# Comparison with Greenplum Features
 
 Cloudberry Database is 100% compatible with Greenplum, and provides all the Greenplum features you need.
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -7,6 +7,18 @@ const youtubeUrl = `https://youtube.com/@cloudberrydb`
 const slackUrl = 'https://communityinviter.com/apps/cloudberrydb/welcome'
 
 const config = {
+  i18n: {
+    defaultLocale: 'en',
+    locales: ['en', 'zh'],
+    localeConfigs: {
+      en: {
+        label: 'English',
+      },
+      zh: {
+        label: '简体中文',
+      },
+    },
+  },
   title: 'Cloudberry Database',
   tagline: 'Open Source MPP Database',
   favicon: 'img/logo.svg',
@@ -45,6 +57,7 @@ const config = {
           sidebarPath: require.resolve('./sidebars.js'),
           editUrl:
             'https://github.com/cloudberrydb/cloudberrydb-site/edit/main/',
+            editLocalizedFiles: true,
         },
         blog: {
           showReadingTime: false,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -44,7 +44,7 @@ const config = {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
           editUrl:
-            'http://github.com/cloudberrydb/cloudberrydb-site/blob/main/',
+            'https://github.com/cloudberrydb/cloudberrydb-site/edit/main/',
         },
         blog: {
           showReadingTime: false,


### PR DESCRIPTION
This PR corrects the "edit" link in the Cloudberry Database doc page and adds i18N setting. When you click "编辑此页", you will be directed to edit the Chinese version instead of the English version.