### PR TITLE
docs: make /docs/ as the default url of cbdb-overview

### DIFF
--- a/docs/cbdb-overview.md
+++ b/docs/cbdb-overview.md
@@ -1,5 +1,6 @@
 ---
 title: Feature Overview
+slug: /
 ---
 
 # Cloudberry Database Feature Overview

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -234,7 +234,7 @@ const config = {
                 },
                 {
                   label: 'Documentation',
-                  to: '/docs/cbdb-overview',
+                  to: '/docs/',
                 },
                 {
                   label: 'Events',

--- a/i18n/zh/docusaurus-plugin-content-docs/current/cbdb-overview.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/cbdb-overview.md
@@ -1,5 +1,6 @@
 ---
 title: 产品特性
+slug: /
 ---
 
 # Cloudberry Database 产品特性

--- a/i18n/zh/docusaurus-theme-classic/footer.json
+++ b/i18n/zh/docusaurus-theme-classic/footer.json
@@ -9,7 +9,7 @@
   },
   "link.item.label.Docs": {
     "message": "文档",
-    "description": "The label of footer link with label=Docs linking to /docs/cbdb-overview"
+    "description": "The label of footer link with label=Docs linking to /docs/"
   },
   "link.item.label.GitHub": {
     "message": "GitHub",

--- a/src/pages/contribute/doc.md
+++ b/src/pages/contribute/doc.md
@@ -44,7 +44,7 @@ create a Pull Request.
 For simple updates such as typo or link fixing in a single document:
 
 1. Navigate to the target page on the [Cloudberry Database
-   documentation site](https://cloudberrydb.io/docs/cbdb-overview) you
+   documentation site](https://cloudberrydb.io/docs/) you
    wish to update.
 2. Click **Edit this page** at the left bottom of the page. This will
    take you to the GitHub edit page for that file.

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -46,7 +46,7 @@ function HomepageHeader() {
           <Link
             style={{ marginRight: "12px" }}
             className="button button--secondary button--lg"
-            to="/docs/cbdb-overview"
+            to="/docs/"
           >
             Discover more
           </Link>

--- a/src/pages/support.md
+++ b/src/pages/support.md
@@ -9,7 +9,7 @@ This page shows that how you can ask for help and get support from our community
 | Type | Description |
 |-------------|----------------|
 |[Download](/download)| You can download the Cloudberry Database releases and see the changelogs.|
-| [Documentation](/docs/cbdb-overview) | Official documentation for Cloudberry Database. You can explore it to discover more details about us. If you want to contribute, see [the guide](/contribute/doc).  |
+| [Documentation](/docs/) | Official documentation for Cloudberry Database. You can explore it to discover more details about us. If you want to contribute, see [the guide](/contribute/doc).  |
 | Report bugs | Problems and issues in Cloudberry Database core. If you find bugs, welcome to submit them [here](https://github.com/cloudberrydb/cloudberrydb/issues).  |
 | Report a security vulnerability | View our [security policy](https://github.com/cloudberrydb/cloudberrydb/security/policy) to learn how to report and contact us.  |
 | Q&A | Ask for help when running/developing Cloudberry Database, visit [GitHub Discussions - QA](https://github.com/orgs/cloudberrydb/discussions/categories/q-a). |


### PR DESCRIPTION
<!--Thank you for contributing! -->

docs: make `/docs/` as the default url of `/docs/cbdb-overview`. This can be good for PDF generation. Other Docusaurus sites also follow this practice.

---

## Change logs

> Describe your change clearly, including what problem is being solved or what document is being added or updated.

## Contributor's checklist

Here are some reminders before you submit your pull request:

* Make sure that your Pull Request has a clear title and commit message. You can take the [Git commit template](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) as a reference.
* Sign the Contributor License Agreement as prompted for your first-time contribution (*One-time setup*).
* Learn the [code contribution](https://cloudberrydb.org/contribute/code) and [doc contribution](https://cloudberrydb.org/contribute/doc) guides for better collaboration.
* Make sure that your changes deployment preview is successful.
* List your communications in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb-site/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
* Feel free to ask for the @cloudberrydb/doc team or other people to help review and approve.
