### PR TITLE
Download page is not found, instead point to github release page.

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -186,7 +186,7 @@ const config: Config = {
           items: [
             {
               label: "Download",
-              to: "/download",
+              href: "https://github.com/cloudberrydb/cloudberrydb/releases",
             },
             {
               label: "Documentation",


### PR DESCRIPTION
The footer Download link points at a non-existent page which generates a 404 (page not found). Instead, have it point at the GitHub Release page (https://github.com/cloudberrydb/cloudberrydb/releases).